### PR TITLE
fix left side major ticks showing floating point cases

### DIFF
--- a/src/dataPlotting.py
+++ b/src/dataPlotting.py
@@ -38,7 +38,11 @@ def plot_timeseries(datacolumns, dates, daily, cumulative, title, filename, ifSh
     lns1 = ax.plot(dates, daily, label="daily cases (weekend-flawed), 2 weeks: red", color='lightgray')
     lns1_2 = ax.plot(dates[-14:], daily[-14:], label="daily cases, last 14 days dark gray", color='red')
     # print (len(dates[-14:]))
-    
+
+    # allow no 'half daily cases' (floating point numbers)
+    yloc = matplotlib.ticker.MaxNLocator(integer=True)
+    ax.yaxis.set_major_locator(yloc)
+
     plt.ylabel("daily cases", color="purple")
     plt.ylim(0, max(daily[1:])*1.5)
 


### PR DESCRIPTION
e.g. for Salzgitter, #3102, the left hand side of the graph shows floating point numbers of daily cases, which of course can not happen.
This gets fixed by this patch.